### PR TITLE
updated resource_ibm_compute_ssl_certificate for CSR parameter

### DIFF
--- a/ibm/resource_ibm_compute_ssl_certificate.go
+++ b/ibm/resource_ibm_compute_ssl_certificate.go
@@ -43,6 +43,13 @@ func resourceIBMComputeSSLCertificate() *schema.Resource {
 				StateFunc: normalizeCert,
 			},
 
+			"certificate_signing_request": &schema.Schema{
+				Type:      schema.TypeString,
+				Optional:  true,
+				ForceNew:  true,
+				StateFunc: normalizeCert,
+			},
+
 			"private_key": &schema.Schema{
 				Type:      schema.TypeString,
 				Required:  true,
@@ -106,9 +113,10 @@ func resourceIBMComputeSSLCertificateCreate(d *schema.ResourceData, meta interfa
 	service := services.GetSecurityCertificateService(sess.SetRetries(0))
 
 	template := datatypes.Security_Certificate{
-		Certificate:             sl.String(d.Get("certificate").(string)),
-		IntermediateCertificate: sl.String(d.Get("intermediate_certificate").(string)),
-		PrivateKey:              sl.String(d.Get("private_key").(string)),
+		Certificate:               sl.String(d.Get("certificate").(string)),
+		IntermediateCertificate:   sl.String(d.Get("intermediate_certificate").(string)),
+		PrivateKey:                sl.String(d.Get("private_key").(string)),
+		CertificateSigningRequest: sl.String(d.Get("certificate_signing_request").(string)),
 	}
 
 	log.Printf("[INFO] Creating Security Certificate")


### PR DESCRIPTION
added a parameter as it was missing in the resource and is present as an optional parameter on the SL portal.